### PR TITLE
Change date format for application command parameters from dd/mm/yyyy…

### DIFF
--- a/src/Inceptum.AppServer/WebApi/Content/js/views/commandPopup.js
+++ b/src/Inceptum.AppServer/WebApi/Content/js/views/commandPopup.js
@@ -46,7 +46,7 @@ define([
                 var deferred = this.deferred = new $.Deferred;
                 this.template = _.template( template, this.command );
                 $(this.el).html(this.template).modal({backdrop:true,show:true});
-                $(this.el).find('.datepicker').datepicker({autoclose:true,format:"dd/mm/yyyy"});
+                $(this.el).find('.datepicker').datepicker({autoclose:true,format:"yyyy-mm-dd"});
                 $('body').append(this.el);
 
                 this.$el.modal({


### PR DESCRIPTION
… to yyyy-mm-dd. So it will be recognized as correct DateTime on most region cultures except only Thai (th), Pashto (ps), Divehi (dv), Dari (prs) and Arabic (ar).
With current date format ("dd/mm/yyyy") value 01/05/2016 will be recognized as January 5th and 17/06/2016 won't be recognized at all if en-US and some other popular cultures are set on server.
